### PR TITLE
Report a per-run session id from the Analytics battery

### DIFF
--- a/src/integration_analytics.rs
+++ b/src/integration_analytics.rs
@@ -37,6 +37,11 @@ const MAX_METADATA_VALUE: usize = 1024;
 /// [`Session::record_error`](crate::Session::record_error) become exception reports with
 /// the error's type, message, cause chain, and a backtrace.
 ///
+/// Every event of one application run carries the same session id (generated afresh per
+/// battery, held only in memory), so the analytics server can assemble the run's page
+/// views, events, and exceptions into a single session trace without making separate
+/// runs correlatable.
+///
 /// Unhandled panics are also captured and reported as exceptions by default; call
 /// [`with_panic_capture(false)`](Analytics::with_panic_capture) to disable this. The panic
 /// hook chains any previously installed hook, and a panicking process may spend up to
@@ -205,6 +210,7 @@ impl BatteryBuilder for Analytics {
             language: sys_locale::get_locale().unwrap_or_else(|| "en".to_string()),
             timezone: iana_time_zone::get_timezone().ok(),
             version: metadata.version.to_string(),
+            session_id: generate_beacon_id(),
             context,
             page: Mutex::new(PageState {
                 beacon: generate_beacon_id(),
@@ -254,6 +260,12 @@ struct AnalyticsCore {
     language: String,
     timezone: Option<String>,
     version: String,
+    /// The per-run session id linking every event this battery reports into one
+    /// session trace on the server (page views rotate their beacon id, but the
+    /// session id is fixed for the lifetime of the battery — mirroring the
+    /// browser tracker, where it is fixed for the lifetime of the page's JS
+    /// context). It exists only in memory, so runs remain uncorrelatable.
+    session_id: String,
     context: BTreeMap<String, String>,
 
     page: Mutex<PageState>,
@@ -429,6 +441,7 @@ impl AnalyticsCore {
         let payload = ExceptionPayload {
             u: self.page_url(&path),
             b: beacon,
+            sid: Some(self.session_id.clone()),
             ty: "panic".to_string(),
             m: truncate_chars(&message, MAX_MESSAGE),
             s: Some(truncate_chars(&stack, MAX_STACK)),
@@ -533,6 +546,7 @@ impl Battery for AnalyticsBattery {
 
         let payload = HitPayload {
             b: beacon,
+            s: Some(self.core.session_id.clone()),
             e: "custom",
             u: self.core.page_url(&path),
             r: None,
@@ -554,6 +568,7 @@ impl Battery for AnalyticsBattery {
         let payload = ExceptionPayload {
             u: self.core.page_url(&path),
             b: Some(beacon),
+            sid: Some(self.core.session_id.clone()),
             ty: truncate_chars(error.error_type, MAX_MESSAGE),
             m: truncate_chars(&error.message, MAX_MESSAGE),
             s: compose_stack(error),
@@ -586,6 +601,7 @@ impl AnalyticsBattery {
 
         let payload = HitPayload {
             b: beacon,
+            s: Some(self.core.session_id.clone()),
             e: "load",
             u: self.core.page_url(&path),
             r: self.referrer.clone(),
@@ -616,6 +632,7 @@ impl AnalyticsBattery {
 
         let payload = HitPayload {
             b: beacon,
+            s: Some(self.core.session_id.clone()),
             e: "unload",
             u: self.core.page_url(&path),
             r: None,
@@ -695,6 +712,9 @@ fn normalize_path(path: &str) -> String {
     }
 }
 
+/// Generates a short random id (base36 timestamp + random suffix), used for both
+/// per-page-view beacon ids and the per-run session id — the same shape the browser
+/// tracker produces.
 fn generate_beacon_id() -> String {
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -810,6 +830,9 @@ impl UniqueVisitTracker {
 struct HitPayload {
     // The beacon ID linking the events of a single page view
     b: String,
+    // The session ID linking every event of this application run
+    #[serde(skip_serializing_if = "Option::is_none")]
+    s: Option<String>,
     // The event kind: "load", "unload" or "custom"
     e: &'static str,
     // The full URL of the page being tracked (required on every kind)
@@ -844,6 +867,10 @@ struct ExceptionPayload {
     // The beacon ID linking the exception to a page view
     #[serde(skip_serializing_if = "Option::is_none")]
     b: Option<String>,
+    // The session ID linking the exception to this application run's session
+    // trace (`s` is taken by the stack on this endpoint)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sid: Option<String>,
     // The exception type name
     ty: String,
     // The exception message
@@ -929,6 +956,7 @@ mod tests {
     fn hit_payload_wire_format() {
         let payload = HitPayload {
             b: "beacon123".to_string(),
+            s: Some("session123".to_string()),
             e: "load",
             u: "https://example.app/home?utm_campaign=1.0.0".to_string(),
             r: None,
@@ -945,6 +973,7 @@ mod tests {
             value,
             serde_json::json!({
                 "b": "beacon123",
+                "s": "session123",
                 "e": "load",
                 "u": "https://example.app/home?utm_campaign=1.0.0",
                 "q": true,
@@ -955,6 +984,7 @@ mod tests {
 
         let payload = HitPayload {
             b: "beacon123".to_string(),
+            s: Some("session123".to_string()),
             e: "custom",
             u: "https://example.app/".to_string(),
             r: None,
@@ -971,6 +1001,7 @@ mod tests {
             value,
             serde_json::json!({
                 "b": "beacon123",
+                "s": "session123",
                 "e": "custom",
                 "u": "https://example.app/",
                 "q": false,
@@ -986,6 +1017,7 @@ mod tests {
         let payload = ExceptionPayload {
             u: "https://example.app/".to_string(),
             b: Some("beacon123".to_string()),
+            sid: Some("session123".to_string()),
             ty: "std::io::Error".to_string(),
             m: "file not found".to_string(),
             s: None,
@@ -1001,6 +1033,7 @@ mod tests {
             serde_json::json!({
                 "u": "https://example.app/",
                 "b": "beacon123",
+                "sid": "session123",
                 "ty": "std::io::Error",
                 "m": "file not found",
                 "h": true,

--- a/src/integration_analytics.rs
+++ b/src/integration_analytics.rs
@@ -441,7 +441,7 @@ impl AnalyticsCore {
         let payload = ExceptionPayload {
             u: self.page_url(&path),
             b: beacon,
-            sid: Some(self.session_id.clone()),
+            i: Some(self.session_id.clone()),
             ty: "panic".to_string(),
             m: truncate_chars(&message, MAX_MESSAGE),
             s: Some(truncate_chars(&stack, MAX_STACK)),
@@ -546,7 +546,7 @@ impl Battery for AnalyticsBattery {
 
         let payload = HitPayload {
             b: beacon,
-            s: Some(self.core.session_id.clone()),
+            i: Some(self.core.session_id.clone()),
             e: "custom",
             u: self.core.page_url(&path),
             r: None,
@@ -568,7 +568,7 @@ impl Battery for AnalyticsBattery {
         let payload = ExceptionPayload {
             u: self.core.page_url(&path),
             b: Some(beacon),
-            sid: Some(self.core.session_id.clone()),
+            i: Some(self.core.session_id.clone()),
             ty: truncate_chars(error.error_type, MAX_MESSAGE),
             m: truncate_chars(&error.message, MAX_MESSAGE),
             s: compose_stack(error),
@@ -601,7 +601,7 @@ impl AnalyticsBattery {
 
         let payload = HitPayload {
             b: beacon,
-            s: Some(self.core.session_id.clone()),
+            i: Some(self.core.session_id.clone()),
             e: "load",
             u: self.core.page_url(&path),
             r: self.referrer.clone(),
@@ -632,7 +632,7 @@ impl AnalyticsBattery {
 
         let payload = HitPayload {
             b: beacon,
-            s: Some(self.core.session_id.clone()),
+            i: Some(self.core.session_id.clone()),
             e: "unload",
             u: self.core.page_url(&path),
             r: None,
@@ -832,7 +832,7 @@ struct HitPayload {
     b: String,
     // The session ID linking every event of this application run
     #[serde(skip_serializing_if = "Option::is_none")]
-    s: Option<String>,
+    i: Option<String>,
     // The event kind: "load", "unload" or "custom"
     e: &'static str,
     // The full URL of the page being tracked (required on every kind)
@@ -868,9 +868,9 @@ struct ExceptionPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     b: Option<String>,
     // The session ID linking the exception to this application run's session
-    // trace (`s` is taken by the stack on this endpoint)
+    // trace (same `i` key as on hits; `s` is taken by the stack here)
     #[serde(skip_serializing_if = "Option::is_none")]
-    sid: Option<String>,
+    i: Option<String>,
     // The exception type name
     ty: String,
     // The exception message
@@ -956,7 +956,7 @@ mod tests {
     fn hit_payload_wire_format() {
         let payload = HitPayload {
             b: "beacon123".to_string(),
-            s: Some("session123".to_string()),
+            i: Some("session123".to_string()),
             e: "load",
             u: "https://example.app/home?utm_campaign=1.0.0".to_string(),
             r: None,
@@ -973,7 +973,7 @@ mod tests {
             value,
             serde_json::json!({
                 "b": "beacon123",
-                "s": "session123",
+                "i": "session123",
                 "e": "load",
                 "u": "https://example.app/home?utm_campaign=1.0.0",
                 "q": true,
@@ -984,7 +984,7 @@ mod tests {
 
         let payload = HitPayload {
             b: "beacon123".to_string(),
-            s: Some("session123".to_string()),
+            i: Some("session123".to_string()),
             e: "custom",
             u: "https://example.app/".to_string(),
             r: None,
@@ -1001,7 +1001,7 @@ mod tests {
             value,
             serde_json::json!({
                 "b": "beacon123",
-                "s": "session123",
+                "i": "session123",
                 "e": "custom",
                 "u": "https://example.app/",
                 "q": false,
@@ -1017,7 +1017,7 @@ mod tests {
         let payload = ExceptionPayload {
             u: "https://example.app/".to_string(),
             b: Some("beacon123".to_string()),
-            sid: Some("session123".to_string()),
+            i: Some("session123".to_string()),
             ty: "std::io::Error".to_string(),
             m: "file not found".to_string(),
             s: None,
@@ -1033,7 +1033,7 @@ mod tests {
             serde_json::json!({
                 "u": "https://example.app/",
                 "b": "beacon123",
-                "sid": "session123",
+                "i": "session123",
                 "ty": "std::io::Error",
                 "m": "file not found",
                 "h": true,


### PR DESCRIPTION
## Summary

Companion to SierraSoftworks/analytics#263, which adds session traces to the analytics server: the tracker-side session id links one visit's page views, custom events, and exceptions into a timeline viewable in the dashboard's new Trace view.

This teaches the `Analytics` battery to report that id:

- `AnalyticsCore` gains a `session_id`, generated once per battery instance (same base36 timestamp + random shape as the beacon ids, and as the browser tracker's ids) — **one application run is one session**. Page views continue to rotate their beacon id; the session id stays fixed for the battery's lifetime.
- Every hit beacon (`load`, `unload`, `custom`) and every exception report — including panic-hook reports — now carries it under the single-letter wire key `i` (previously unused in the tracking API; `s` is taken by the stack on the exception endpoint), matching the server's `TrackEvent` / `ExceptionReport` DTOs.
- The id lives only in memory and is regenerated each run, mirroring the browser tracker's privacy model: separate runs remain uncorrelatable, and servers predating the field simply ignore it.

## Testing

- `cargo test --all-features`: all unit, integration, and doc tests pass, with the wire-format tests extended to assert the new `i` key serializes as expected on both payloads.
- `cargo fmt --check` clean; `cargo clippy --all-features --all-targets` introduces no new warnings (the 8 existing warnings are in unrelated integrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WatBhTRVQxp4mpDEewqRmT